### PR TITLE
handling IOError exception when trying to load missing dicom files

### DIFF
--- a/pylidc/Scan.py
+++ b/pylidc/Scan.py
@@ -312,8 +312,11 @@ class Scan(Base):
 
         images = []
         for dicom_file_name in sorted_fnames:
-            with open(os.path.join(path, dicom_file_name), 'rb') as f:
-                images.append( dicom.read_file(f) )
+            try
+                with open(os.path.join(path, dicom_file_name), 'rb') as f:
+                    images.append( dicom.read_file(f) )
+            except IOErro as e:
+                print dicom_file_name, "does not exist. it's skipped."
         return images
 
     def visualize(self, annotation_groups=None):


### PR DESCRIPTION
Recently, I have used PyLIDC a lot. This is a great project.
I found a small bug when I am using it.
LIDC-IDRI dataset often does not have files which is in the filename DB of PyLIDC.
It raise an IOError exception, and kills a program.