### PR TITLE
Refactor configuration file checks and set up

### DIFF
--- a/pylidc/__init__.py
+++ b/pylidc/__init__.py
@@ -20,7 +20,7 @@ For more information, see the model classes themselves.
 """
 from __future__ import print_function as _pf
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 # Hidden stuff.
 import os as _os
@@ -34,7 +34,6 @@ _session = _sessionmaker(bind=_engine)()
 
 # Public stuff.
 from .Scan       import Scan
-from .Scan       import dicompath
 from .Annotation import Annotation
 from .Contour    import Contour
 from .Zval       import Zval


### PR DESCRIPTION
* Places config file location and name set up into getters
* Creates default template configuration when it doesn't exist rather than printing obnoxious warning on every import

closes #19 